### PR TITLE
fix bug, fileBasename and fileBasenameNoExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Now you can enable `pasteImage.showFilePathConfirmInputBox` to modify file path 
     
     - `${currentFileDir}`: the path of directory that contain current editing file. 
     - `${projectRoot}`: the path of the project opened in vscode.
-    - `${currentFileName}`: the current file name with ext.
-    - `${currentFileNameWithoutExt}`: the current file name without ext.
+    - `${fileBasename}`: the current file name with ext.
+    - `${fileBasenameNoExtension}`: the current file name without ext.
 
     Default value is `./`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,7 @@ class PasterConfig {
         if (path.isAbsolute(savefolder)) {
             return vscode.Uri.file(savefolder);
         }
-        return vscode.Uri.joinPath(uri, savefolder);
+        return vscode.Uri.joinPath(uri, "../", savefolder);
     }
 
     public static getPasteTemplate(languageId: string): string {

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -106,19 +106,19 @@ class PasteTarget {
         const tpl = PasterConfig.getPasteTemplate(lang);
  
         const filePath:string = getRelativePath(baseUri, imageUri);
-        const predefinedVars = new PredefinedVars(baseUri);
+        const predefinedVars = new PredefinedVars(this.editor.document.uri);
         predefinedVars.set("relativePath", filePath);
 
         return predefinedVars.replace(tpl);
     }
 
     public getPasteBase64ImageText(imageUri:vscode.Uri, base64:string):string[] {
-        const baseUri = this.getBaseUri();
+        // const baseUri = this.getBaseUri();
         const lang = this.editor.document.languageId;
         const tpls = PasterConfig.getPasteBase64Template(lang);
         
         const filePath:string = path.basename(imageUri.fsPath);
-        const predefinedVars = new PredefinedVars(baseUri);
+        const predefinedVars = new PredefinedVars(this.editor.document.uri);
         predefinedVars.set("relativePath", filePath);
         predefinedVars.set("base64", base64);
 
@@ -127,7 +127,7 @@ class PasteTarget {
     
     public getImagePath():vscode.Uri {
         let baseUri = this.getBaseUri();
-        baseUri = PasterConfig.getBasePath(baseUri);
+        baseUri = PasterConfig.getBasePath(this.editor.document.uri);
 
         const content = this.getSelectText();
         const predefinedVars = new PredefinedVars(this.editor.document.uri);

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -156,6 +156,7 @@ class PasteTarget {
     }
 
     public pasteText(context:string){
+        context = decodeURI(context);
         return this.editor.edit(edit => {
             const current = this.editor.selection;
 

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -7,7 +7,7 @@ import {PasterConfig, PredefinedVars} from '../../config';
 import moment = require('moment');
 
 function sleep(time:number) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         setTimeout(() => {
             resolve();
         }, time);
@@ -54,9 +54,9 @@ describe('Extension Test Suite (config)', () => {
 	});
 
 	it('getBasePath test relative', async () => {
-		const uri:vscode.Uri = vscode.Uri.joinPath(rootDir, "sample");
+		const uri:vscode.Uri = vscode.Uri.joinPath(rootDir, "zzz/sample.abc");
 		await conf.update('path', './');
-		assert.equal(""+uri+"/", ""+PasterConfig.getBasePath(uri));
+		assert.equal(""+rootDir+"/zzz/", ""+PasterConfig.getBasePath(uri));
 	});
 
 	it('getBasePath test absolute', async () => {
@@ -87,13 +87,13 @@ describe('Extension Test Suite (config)', () => {
 	it('getBasePath test fileBasenameNoExtension', async () => {
 		const uri:vscode.Uri = vscode.Uri.joinPath(rootDir, "zzz/sample.abc");
 		await conf.update('path', "${fileBasenameNoExtension}");
-		assert.equal(""+uri+"/sample", ""+PasterConfig.getBasePath(uri));
+		assert.equal(""+rootDir+"/zzz/sample", ""+PasterConfig.getBasePath(uri));
 	});
 
 	it('getBasePath test fileBasename', async () => {
 		const uri:vscode.Uri = vscode.Uri.joinPath(rootDir, "zzz/sample.abc");
 		await conf.update('path', "${fileBasename}");
-		assert.equal(""+uri+"/sample.abc", ""+PasterConfig.getBasePath(uri));
+		assert.equal(""+rootDir+"/zzz/sample.abc", ""+PasterConfig.getBasePath(uri));
 	});
 
 	it('getBasePath test fileDirname', async () => {


### PR DESCRIPTION
Thanks for your working. The bug below is fixed, plz.
- In config file, varibale 'fileBasename' and 'fileBasenameNoExtension' misrouted to real file's directory, not exactly the file
- In readme file, change 'currentFileName' to 'fileBasename', change 'currentFileNameWithoutExt' to 'fileBasenameNoExtension'